### PR TITLE
perf(frequency): Back Frequencies with hashbrown 0.17, use entry_ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ pub trait Commute: Sized {
 | **online.rs** | `OnlineStats` | Constant-space streaming mean/variance/stddev using Welford's method. Cache-optimized field layout (hot/warm/cold paths). |
 | **unsorted.rs** | `Unsorted<T>` | Collects data, lazily sorts on demand. Median, quartiles (Method 3), mode/antimodes, Gini, kurtosis, Atkinson index, MAD, percentile rank. |
 | **sorted.rs** | — | Statistics on pre-sorted sequences via `BinaryHeap`. |
-| **frequency.rs** | `Frequencies<T>` | Exact frequency counting using `foldhash::HashMap`. Cardinality, most/least frequent. |
+| **frequency.rs** | `Frequencies<T>` | Exact frequency counting using `hashbrown::HashMap` (foldhash hasher; `entry_ref` for borrowed byte-slice inserts). Cardinality, most/least frequent. |
 | **minmax.rs** | `MinMax<T>` | Min/max tracking with sort order detection (`sortiness()` returns -1.0 to 1.0). |
 
 ### Performance Patterns
@@ -60,4 +60,4 @@ Tests are embedded in each module via `#[cfg(test)]` blocks (140+ tests total). 
 
 ## Dependencies
 
-Only 4 production dependencies: `foldhash`, `num-traits`, `rayon`, `serde`.
+Only 4 production dependencies: `hashbrown` (default foldhash 0.2 hasher), `num-traits`, `rayon`, `serde`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ rust-version  = "1.95"
 name = "stats"
 
 [dependencies]
-foldhash   = "0.2"
+hashbrown  = "0.17"                                                 # default hasher is foldhash 0.2
 num-traits = "0.2"
 rayon      = "1"
 serde      = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.8"
+foldhash  = "0.2" # only for the std-vs-hashbrown comparison in benches/freqhb.rs
 
 [[bench]]
 name    = "minmax"
@@ -35,4 +36,8 @@ harness = false
 
 [[bench]]
 name    = "sortcmp"
+harness = false
+
+[[bench]]
+name    = "freqhb"
 harness = false

--- a/benches/freqhb.rs
+++ b/benches/freqhb.rs
@@ -1,0 +1,181 @@
+// Faithful comparison of Frequencies<Vec<u8>>'s std-HashMap backing vs a
+// hashbrown 0.17 backing, for both hot paths qsv uses:
+//   - build  (add_borrowed per cell)
+//   - merge  (per-column partial tables combined via Commute::merge)
+//
+// hashbrown 0.16+ uses foldhash 0.2 as its DEFAULT hasher — the SAME hash
+// qsv-stats already uses — so hashbrown::HashMap::new() here hashes identically
+// to foldhash::HashMap. This isolates the table implementation, not the hash.
+//
+// Build: std path mirrors the library (get_mut -> insert-on-miss); hashbrown
+// path uses entry_ref (single borrowed probe).
+// Merge: both use the library's entry(owned-key) vacant/occupied pattern.
+//
+// RESULT (justifies the swap, 1M rows): hashbrown wins on both paths with
+// identical hashing. Build: -7-8% high-cardinality (the dominant cost), -14-20%
+// low-cardinality. Merge: -15% low-card, ~-3% high-card. foldhash stays as a
+// dev-dependency solely to keep the `std` baseline in this bench.
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::collections::hash_map::Entry as StdEntry;
+
+use hashbrown::hash_map::Entry as HbEntry;
+
+fn lcg(seed: u64) -> impl FnMut() -> u64 {
+    let mut s = seed;
+    move || {
+        s = s
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        s
+    }
+}
+
+fn gen_low_card(n: usize, card: usize) -> Vec<Vec<u8>> {
+    let mut next = lcg(0xABCD_1234_5678_9999);
+    let pool: Vec<Vec<u8>> = (0..card)
+        .map(|i| format!("category_{i:04}").into_bytes())
+        .collect();
+    (0..n).map(|_| pool[(next() as usize) % card].clone()).collect()
+}
+
+fn gen_high_card_short(n: usize) -> Vec<Vec<u8>> {
+    (0..n).map(|i| format!("{i:08}").into_bytes()).collect()
+}
+
+fn gen_high_card_long(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| format!("urn:example:record:{i:020}:payload-segment-xyz").into_bytes())
+        .collect()
+}
+
+// ---- build ----
+fn build_std(data: &[Vec<u8>]) -> u64 {
+    let mut map: foldhash::HashMap<Vec<u8>, u64> = foldhash::HashMapExt::with_capacity(1024);
+    for v in data {
+        if let Some(c) = map.get_mut(v.as_slice()) {
+            *c += 1;
+        } else {
+            map.insert(v.clone(), 1);
+        }
+    }
+    map.len() as u64
+}
+
+fn build_hb(data: &[Vec<u8>]) -> u64 {
+    // Default hasher == foldhash 0.2 (hashbrown 0.16+).
+    let mut map: hashbrown::HashMap<Vec<u8>, u64> = hashbrown::HashMap::with_capacity(1024);
+    for v in data {
+        *map.entry_ref(v.as_slice()).or_insert(0) += 1;
+    }
+    map.len() as u64
+}
+
+// ---- merge ----
+// Build `parts` partial tables from contiguous slices (mirrors qsv's per-chunk
+// frequency tables), then time merging them all into one.
+fn make_std_partials(data: &[Vec<u8>], parts: usize) -> Vec<foldhash::HashMap<Vec<u8>, u64>> {
+    let chunk = data.len().div_ceil(parts);
+    data.chunks(chunk)
+        .map(|c| {
+            let mut m: foldhash::HashMap<Vec<u8>, u64> = foldhash::HashMapExt::with_capacity(256);
+            for v in c {
+                *m.entry(v.clone()).or_insert(0) += 1;
+            }
+            m
+        })
+        .collect()
+}
+
+fn merge_std(mut partials: Vec<foldhash::HashMap<Vec<u8>, u64>>) -> u64 {
+    let mut acc = partials.swap_remove(0);
+    for p in partials {
+        acc.reserve(p.len());
+        for (k, v2) in p {
+            match acc.entry(k) {
+                StdEntry::Vacant(e) => {
+                    e.insert(v2);
+                }
+                StdEntry::Occupied(mut e) => *e.get_mut() += v2,
+            }
+        }
+    }
+    acc.len() as u64
+}
+
+fn make_hb_partials(data: &[Vec<u8>], parts: usize) -> Vec<hashbrown::HashMap<Vec<u8>, u64>> {
+    let chunk = data.len().div_ceil(parts);
+    data.chunks(chunk)
+        .map(|c| {
+            let mut m: hashbrown::HashMap<Vec<u8>, u64> = hashbrown::HashMap::with_capacity(256);
+            for v in c {
+                *m.entry_ref(v.as_slice()).or_insert(0) += 1;
+            }
+            m
+        })
+        .collect()
+}
+
+fn merge_hb(mut partials: Vec<hashbrown::HashMap<Vec<u8>, u64>>) -> u64 {
+    let mut acc = partials.swap_remove(0);
+    for p in partials {
+        acc.reserve(p.len());
+        for (k, v2) in p {
+            match acc.entry(k) {
+                HbEntry::Vacant(e) => {
+                    e.insert(v2);
+                }
+                HbEntry::Occupied(mut e) => *e.get_mut() += v2,
+            }
+        }
+    }
+    acc.len() as u64
+}
+
+fn bench_build(c: &mut Criterion) {
+    let n = 1_000_000usize;
+    let shapes: &[(&str, Vec<Vec<u8>>)] = &[
+        ("low_card_50", gen_low_card(n, 50)),
+        ("low_card_5000", gen_low_card(n, 5000)),
+        ("high_card_short", gen_high_card_short(n)),
+        ("high_card_long", gen_high_card_long(n)),
+    ];
+    let mut group = c.benchmark_group("build");
+    group.throughput(Throughput::Elements(n as u64));
+    group.sample_size(20);
+    for (label, data) in shapes {
+        assert_eq!(build_std(data), build_hb(data));
+        group.bench_with_input(BenchmarkId::new("std", label), data, |b, d| {
+            b.iter(|| black_box(build_std(d)));
+        });
+        group.bench_with_input(BenchmarkId::new("hashbrown", label), data, |b, d| {
+            b.iter(|| black_box(build_hb(d)));
+        });
+    }
+    group.finish();
+}
+
+fn bench_merge(c: &mut Criterion) {
+    let n = 1_000_000usize;
+    let parts = 16;
+    let shapes: &[(&str, Vec<Vec<u8>>)] = &[
+        ("low_card_5000", gen_low_card(n, 5000)),
+        ("high_card_short", gen_high_card_short(n)),
+    ];
+    let mut group = c.benchmark_group("merge");
+    group.throughput(Throughput::Elements(n as u64));
+    group.sample_size(20);
+    for (label, data) in shapes {
+        let std_parts = make_std_partials(data, parts);
+        let hb_parts = make_hb_partials(data, parts);
+        group.bench_with_input(BenchmarkId::new("std", label), &std_parts, |b, p| {
+            b.iter_batched(|| p.clone(), |p| black_box(merge_std(p)), criterion::BatchSize::LargeInput);
+        });
+        group.bench_with_input(BenchmarkId::new("hashbrown", label), &hb_parts, |b, p| {
+            b.iter_batched(|| p.clone(), |p| black_box(merge_hb(p)), criterion::BatchSize::LargeInput);
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_build, bench_merge);
+criterion_main!(benches);

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -1,7 +1,7 @@
-use std::collections::hash_map::{Entry, Keys};
 use std::hash::Hash;
 
-use foldhash::{HashMap, HashMapExt};
+use hashbrown::HashMap;
+use hashbrown::hash_map::{Entry, Keys};
 
 use rayon::prelude::*;
 
@@ -249,28 +249,22 @@ impl<T: Eq + Hash> Frequencies<T> {
 
 impl Frequencies<Vec<u8>> {
     /// Increment count for a byte slice key, avoiding allocation when key exists.
-    /// Uses borrowed lookup via `get_mut(&[u8])` before falling back to owned insert.
-    /// This works because `Vec<u8>: Borrow<[u8]>`, so `HashMap` accepts `&[u8]` for lookup.
-    /// For low-cardinality columns (the common case), this eliminates ~99% of allocations.
+    /// Uses hashbrown's `entry_ref(&[u8])`, which probes once with the borrowed
+    /// key and only allocates (`[u8]::to_owned()` -> `Vec<u8>`) on the vacant
+    /// branch. For low-cardinality columns (the common case), this eliminates
+    /// ~99% of allocations; for new keys it is a single hash+probe (std's
+    /// HashMap has no stable raw-entry API, so the old path hashed twice).
     #[allow(clippy::inline_always)]
     #[inline(always)]
     pub fn add_borrowed(&mut self, v: &[u8]) {
-        if let Some(count) = self.data.get_mut(v) {
-            *count += 1;
-        } else {
-            self.data.insert(v.to_vec(), 1);
-        }
+        *self.data.entry_ref(v).or_insert(0) += 1;
     }
 
     /// Increment by a count for a byte slice key, avoiding allocation when key exists.
     #[allow(clippy::inline_always)]
     #[inline(always)]
     pub fn increment_by_borrowed(&mut self, v: &[u8], count: u64) {
-        if let Some(existing) = self.data.get_mut(v) {
-            *existing += count;
-        } else {
-            self.data.insert(v.to_vec(), count);
-        }
+        *self.data.entry_ref(v).or_insert(0) += count;
     }
 }
 


### PR DESCRIPTION
## Summary

Swaps the `Frequencies` backing map from std `HashMap` (via `foldhash::HashMap`) to `hashbrown::HashMap`, and switches the byte-slice insert hot path to hashbrown's `entry_ref`.

The enabling detail from hashbrown's changelog: **hashbrown 0.16+ uses foldhash 0.2 as its default hasher** — the exact hash qsv-stats already used. So hashing is **unchanged**; only the table implementation differs.

## Why it's a dependency swap, not an addition

`foldhash` was used in exactly one place (`frequency.rs`, the crate's only HashMap user). After the swap:
- Direct production deps stay at **4**: `foldhash` → `hashbrown` (`num-traits`, `rayon`, `serde` unchanged).
- `foldhash` 0.2 remains in the tree **transitively** under hashbrown — a single copy, no duplication.
- Net-new transitive crates: `allocator-api2`, `equivalent` (both tiny).

## The hot-path change

`add_borrowed` / `increment_by_borrowed` previously did `get_mut(&[u8])` then `insert(v.to_vec())` on a miss. std's HashMap has no stable raw-entry API, so a **new** key was hashed + probed **twice**. hashbrown's `entry_ref` probes once with the borrowed key and only allocates (`[u8]::to_owned()`) on the vacant branch. Result is identical (verified by the unchanged test suite + a cardinality assertion in the bench).

## Benchmarks (1M rows, identical hashing — `benches/freqhb.rs`)

**build** (`add_borrowed`):

| shape | std | hashbrown | delta |
|---|---|---|---|
| low_card_50 | 3.82 ms | 3.05 ms | −20% |
| low_card_5000 | 6.12 ms | 5.28 ms | −14% |
| high_card_short | 54.3 ms | 50.0 ms | −8% |
| high_card_long | 93.3 ms | 87.0 ms | −7% |

**merge** (`Commute::merge` pattern):

| shape | std | hashbrown | delta |
|---|---|---|---|
| low_card_5000 | 1.18 ms | 1.00 ms | −15% |
| high_card_short | 40.2 ms | 38.8 ms | −3.5% (noisy) |

The high-cardinality build is the dominant wall-clock cost in qsv's `frequency` command, and it improves ~7–8%.

`foldhash` is kept as a **dev-dependency** solely to retain the `std` baseline in the comparison bench.

## Test plan

- `cargo test --lib` — 161 passed, 0 failed
- `cargo clippy --lib` — clean
- `cargo bench --bench freqhb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)