### PR TITLE
v 0.53.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "qsv-stats"
-version       = "0.52.0"                                            #:version
+version       = "0.53.0"                                            #:version
 authors       = ["Joel Natividad <joel@dathere.com>"]
 description   = "Computing summary statistics on streams."
 documentation = "https://docs.rs/qsv-stats"


### PR DESCRIPTION
## Release-hygiene bump: 0.53.0

`0.52.0` shipped a real fix (`top_n` tie-break alignment) and was published to crates.io + pushed to `master`, but the release was incomplete: **no git tag, no GitHub release, no dedicated release commit** (the bump was folded into fix commit `571f349`). crates.io versions are immutable, so this PR supersedes it with a clean, properly-tracked **0.53.0**.

### Changes
- Bump `Cargo.toml` `#:version` `0.52.0 → 0.53.0` (release-hygiene only — no functional change in this PR).

### Companion cleanup (already done on `master`/origin)
- Retroactively tagged `0.52.0` on `571f349` to restore traceability of the published version.

### User-visible behavior change since 0.51.0 (carried from 0.52.0)
**`fix(frequency)`: align `top_n` tie-break with `par_frequent`.** `top_n(n)` now ranks heap candidates on `(count, Reverse(item))` so the kept set is "largest count, smallest value on tie" and emits `count desc / value asc` — **byte-identical to `par_frequent(false)[..n]`**. Previously it tie-broke on the lexicographically *largest* value, selecting a different set than `par_frequent(false)` truncated to `n` whenever counts tied across the n/n+1 boundary. `bottom_n()` already matched `par_frequent(true)` and is unchanged. Equivalence tests added: `top_n_matches_par_frequent_all_ties`, `top_n_matches_par_frequent_boundary_ties`.

### Verification
- `cargo test`: 163 unit + 5 doctests passing.
- `cargo clippy --all-targets`: lib clean (only pre-existing bench `type_complexity` warnings).
- `cargo publish --dry-run`: packages & verifies cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)